### PR TITLE
Improve API key management and load Pokémon dynamically

### DIFF
--- a/Pokemon_fusion.html
+++ b/Pokemon_fusion.html
@@ -321,6 +321,12 @@
             font-family: monospace;
             font-size: 0.9rem;
         }
+        .api-key-item .comment-text {
+            flex-grow: 1;
+            margin-left: 10px;
+            color: #666;
+            font-size: 0.9rem;
+        }
         .api-key-item .delete-btn {
             background-color: #dc3545;
             color: white;
@@ -333,6 +339,19 @@
         }
         .api-key-item .delete-btn:hover {
             background-color: #c82333;
+        }
+        .api-key-item .edit-btn {
+            background-color: #007bff;
+            color: white;
+            border: none;
+            padding: 5px 10px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            margin-left: 10px;
+        }
+        .api-key-item .edit-btn:hover {
+            background-color: #0056b3;
         }
         @media (max-width: 768px) {
             h1 {
@@ -365,6 +384,7 @@
             </h3>
             <div class="api-key-input-container">
                 <input type="password" id="apiKeyInput" class="api-key-input" placeholder="Enter your Gemini API Key">
+                <input type="text" id="apiCommentInput" class="api-key-input" placeholder="Comment (optional)">
                 <button id="addApiKeyButton" class="api-key-button">Add API Key</button>
                 <ul id="apiKeysList" class="api-keys-list"></ul>
                 <div id="apiKeyStatus" class="api-key-status"></div>
@@ -438,230 +458,47 @@
         const resultDescription = document.getElementById('resultDescription');
         const notification = document.getElementById('notification');
         const apiKeyInput = document.getElementById('apiKeyInput');
+        const apiCommentInput = document.getElementById('apiCommentInput');
         const addApiKeyButton = document.getElementById('addApiKeyButton');
         const apiKeyStatus = document.getElementById('apiKeyStatus');
         const apiKeysList = document.getElementById('apiKeysList');
         const serverWarning = document.getElementById('serverWarning');
         const connectionStatus = document.getElementById('connectionStatus');
 
-        // Pre-defined Pokémon data (first 151) as fallback
-        const predefinedPokemon = [
-            { id: 1, name: "bulbasaur", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png" } },
-            { id: 2, name: "ivysaur", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/2.png" } },
-            { id: 3, name: "venusaur", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/3.png" } },
-            { id: 4, name: "charmander", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png" } },
-            { id: 5, name: "charmeleon", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/5.png" } },
-            { id: 6, name: "charizard", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/6.png" } },
-            { id: 7, name: "squirtle", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png" } },
-            { id: 8, name: "wartortle", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/8.png" } },
-            { id: 9, name: "blastoise", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/9.png" } },
-            { id: 10, name: "caterpie", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/10.png" } },
-            { id: 11, name: "metapod", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/11.png" } },
-            { id: 12, name: "butterfree", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/12.png" } },
-            { id: 13, name: "weedle", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/13.png" } },
-            { id: 14, name: "kakuna", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/14.png" } },
-            { id: 15, name: "beedrill", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/15.png" } },
-            { id: 16, name: "pidgey", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/16.png" } },
-            { id: 17, name: "pidgeotto", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/17.png" } },
-            { id: 18, name: "pidgeot", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/18.png" } },
-            { id: 19, name: "rattata", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/19.png" } },
-            { id: 20, name: "raticate", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/20.png" } },
-            { id: 21, name: "spearow", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/21.png" } },
-            { id: 22, name: "fearow", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/22.png" } },
-            { id: 23, name: "ekans", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/23.png" } },
-            { id: 24, name: "arbok", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/24.png" } },
-            { id: 25, name: "pikachu", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png" } },
-            { id: 26, name: "raichu", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/26.png" } },
-            { id: 27, name: "sandshrew", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/27.png" } },
-            { id: 28, name: "sandslash", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/28.png" } },
-            { id: 29, name: "nidoran-f", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/29.png" } },
-            { id: 30, name: "nidorina", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/30.png" } },
-            { id: 31, name: "nidoqueen", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/31.png" } },
-            { id: 32, name: "nidoran-m", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/32.png" } },
-            { id: 33, name: "nidorino", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/33.png" } },
-            { id: 34, name: "nidoking", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/34.png" } },
-            { id: 35, name: "clefairy", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/35.png" } },
-            { id: 36, name: "clefable", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/36.png" } },
-            { id: 37, name: "vulpix", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/37.png" } },
-            { id: 38, name: "ninetales", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/38.png" } },
-            { id: 39, name: "jigglypuff", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/39.png" } },
-            { id: 40, name: "wigglytuff", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/40.png" } },
-            { id: 41, name: "zubat", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/41.png" } },
-            { id: 42, name: "golbat", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/42.png" } },
-            { id: 43, name: "oddish", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/43.png" } },
-            { id: 44, name: "gloom", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/44.png" } },
-            { id: 45, name: "vileplume", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/45.png" } },
-            { id: 46, name: "paras", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/46.png" } },
-            { id: 47, name: "parasect", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/47.png" } },
-            { id: 48, name: "venonat", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/48.png" } },
-            { id: 49, name: "venomoth", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/49.png" } },
-            { id: 50, name: "diglett", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/50.png" } },
-            { id: 51, name: "dugtrio", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/51.png" } },
-            { id: 52, name: "meowth", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/52.png" } },
-            { id: 53, name: "persian", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/53.png" } },
-            { id: 54, name: "psyduck", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/54.png" } },
-            { id: 55, name: "golduck", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/55.png" } },
-            { id: 56, name: "mankey", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/56.png" } },
-            { id: 57, name: "primeape", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/57.png" } },
-            { id: 58, name: "growlithe", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/58.png" } },
-            { id: 59, name: "arcanine", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/59.png" } },
-            { id: 60, name: "poliwag", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/60.png" } },
-            { id: 61, name: "poliwhirl", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/61.png" } },
-            { id: 62, name: "poliwrath", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/62.png" } },
-            { id: 63, name: "abra", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/63.png" } },
-            { id: 64, name: "kadabra", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/64.png" } },
-            { id: 65, name: "alakazam", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/65.png" } },
-            { id: 66, name: "machop", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/66.png" } },
-            { id: 67, name: "machoke", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/67.png" } },
-            { id: 68, name: "machamp", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/68.png" } },
-            { id: 69, name: "bellsprout", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/69.png" } },
-            { id: 70, name: "weepinbell", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/70.png" } },
-            { id: 71, name: "victreebel", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/71.png" } },
-            { id: 72, name: "tentacool", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/72.png" } },
-            { id: 73, name: "tentacruel", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/73.png" } },
-            { id: 74, name: "geodude", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/74.png" } },
-            { id: 75, name: "graveler", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/75.png" } },
-            { id: 76, name: "golem", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/76.png" } },
-            { id: 77, name: "ponyta", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/77.png" } },
-            { id: 78, name: "rapidash", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/78.png" } },
-            { id: 79, name: "slowpoke", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/79.png" } },
-            { id: 80, name: "slowbro", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/80.png" } },
-            { id: 81, name: "magnemite", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/81.png" } },
-            { id: 82, name: "magneton", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/82.png" } },
-            { id: 83, name: "farfetchd", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/83.png" } },
-            { id: 84, name: "doduo", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/84.png" } },
-            { id: 85, name: "dodrio", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/85.png" } },
-            { id: 86, name: "seel", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/86.png" } },
-            { id: 87, name: "dewgong", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/87.png" } },
-            { id: 88, name: "grimer", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/88.png" } },
-            { id: 89, name: "muk", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/89.png" } },
-            { id: 90, name: "shellder", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/90.png" } },
-            { id: 91, name: "cloyster", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/91.png" } },
-            { id: 92, name: "gastly", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/92.png" } },
-            { id: 93, name: "haunter", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/93.png" } },
-            { id: 94, name: "gengar", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/94.png" } },
-            { id: 95, name: "onix", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/95.png" } },
-            { id: 96, name: "drowzee", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/96.png" } },
-            { id: 97, name: "hypno", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/97.png" } },
-            { id: 98, name: "krabby", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/98.png" } },
-            { id: 99, name: "kingler", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/99.png" } },
-            { id: 100, name: "voltorb", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/100.png" } },
-            { id: 101, name: "electrode", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/101.png" } },
-            { id: 102, name: "exeggcute", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/102.png" } },
-            { id: 103, name: "exeggutor", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/103.png" } },
-            { id: 104, name: "cubone", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/104.png" } },
-            { id: 105, name: "marowak", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/105.png" } },
-            { id: 106, name: "hitmonlee", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/106.png" } },
-            { id: 107, name: "hitmonchan", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/107.png" } },
-            { id: 108, name: "lickitung", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/108.png" } },
-            { id: 109, name: "koffing", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/109.png" } },
-            { id: 110, name: "weezing", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/110.png" } },
-            { id: 111, name: "rhyhorn", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/111.png" } },
-            { id: 112, name: "rhydon", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/112.png" } },
-            { id: 113, name: "chansey", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/113.png" } },
-            { id: 114, name: "tangela", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/114.png" } },
-            { id: 115, name: "kangaskhan", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/115.png" } },
-            { id: 116, name: "horsea", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/116.png" } },
-            { id: 117, name: "seadra", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/117.png" } },
-            { id: 118, name: "goldeen", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/118.png" } },
-            { id: 119, name: "seaking", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/119.png" } },
-            { id: 120, name: "staryu", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/120.png" } },
-            { id: 121, name: "starmie", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/121.png" } },
-            { id: 122, name: "mr-mime", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/122.png" } },
-            { id: 123, name: "scyther", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/123.png" } },
-            { id: 124, name: "jynx", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/124.png" } },
-            { id: 125, name: "electabuzz", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/125.png" } },
-            { id: 126, name: "magmar", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/126.png" } },
-            { id: 127, name: "pinsir", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/127.png" } },
-            { id: 128, name: "tauros", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/128.png" } },
-            { id: 129, name: "magikarp", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/129.png" } },
-            { id: 130, name: "gyarados", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/130.png" } },
-            { id: 131, name: "lapras", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/131.png" } },
-            { id: 132, name: "ditto", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/132.png" } },
-            { id: 133, name: "eevee", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/133.png" } },
-            { id: 134, name: "vaporeon", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/134.png" } },
-            { id: 135, name: "jolteon", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/135.png" } },
-            { id: 136, name: "flareon", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/136.png" } },
-            { id: 137, name: "porygon", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/137.png" } },
-            { id: 138, name: "omanyte", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/138.png" } },
-            { id: 139, name: "omastar", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/139.png" } },
-            { id: 140, name: "kabuto", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/140.png" } },
-            { id: 141, name: "kabutops", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/141.png" } },
-            { id: 142, name: "aerodactyl", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/142.png" } },
-            { id: 143, name: "snorlax", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/143.png" } },
-            { id: 144, name: "articuno", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/144.png" } },
-            { id: 145, name: "zapdos", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/145.png" } },
-            { id: 146, name: "moltres", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/146.png" } },
-            { id: 147, name: "dratini", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/147.png" } },
-            { id: 148, name: "dragonair", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/148.png" } },
-            { id: 149, name: "dragonite", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/149.png" } },
-            { id: 150, name: "mewtwo", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/150.png" } },
-            { id: 151, name: "mew", sprites: { front_default: "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/151.png" } }
-        ];
-
-        // Check if running from a server
         function checkServerStatus() {
-            if (window.location.protocol === 'file:') {
-                serverWarning.style.display = 'block';
-                isRunningFromServer = false;
-                connectionStatus.className = 'status-indicator status-offline';
-            } else {
-                serverWarning.style.display = 'none';
-                isRunningFromServer = true;
-                connectionStatus.className = 'status-indicator status-online';
-            }
+            isRunningFromServer = location.protocol !== 'file:';
+            connectionStatus.className = isRunningFromServer ?
+                'status-indicator status-online' :
+                'status-indicator status-offline';
+            serverWarning.style.display = isRunningFromServer ? 'none' : 'block';
         }
 
-        // Show server instructions
-        function showServerInstructions() {
-            const instructions = "To run this website properly, you need to use a local server:\n" +
-                "1. Python method (easiest):\n" +
-                "   - Open Command Prompt/Terminal\n" +
-                "   - Navigate to the folder with this HTML file\n" +
-                "   - Run: python -m http.server\n" +
-                "   - Open: http://localhost:8000\n" +
-                "2. Node.js method:\n" +
-                "   - Install: npm install -g http-server\n" +
-                "   - Run: http-server\n" +
-                "   - Open: http://localhost:8000\n" +
-                "3. VS Code method:\n" +
-                "   - Install \"Live Server\" extension\n" +
-                "   - Right-click file and select \"Open with Live Server\"";
-            alert(instructions);
-        }
-
-        // Initialize the app
         async function init() {
             checkServerStatus();
-            // Try to load saved API keys
             try {
                 const savedApiKeys = JSON.parse(localStorage.getItem('geminiApiKeys')) || [];
                 if (savedApiKeys.length > 0) {
-                    geminiApiKeys = savedApiKeys;
+                    geminiApiKeys = savedApiKeys.map(k =>
+                        typeof k === 'string' ? { key: k, comment: '' } : k
+                    );
                     renderApiKeys();
                     updateApiKeyStatus(true);
                 }
             } catch (e) {
                 console.warn('localStorage not available:', e);
             }
-            // Always load Pokémon from predefined data first
-            loadPredefinedPokemon();
-            // Try to fetch from API if running from server
-            if (isRunningFromServer) {
-                try {
-                    await fetchPokemon();
-                } catch (error) {
-                    console.error('API fetch failed, using predefined data:', error);
-                    showNotification('Using offline Pokémon data. Some features may be limited.');
-                }
-            }
-        }
 
-        // Load Pokémon from predefined data
-        function loadPredefinedPokemon() {
-            allPokemon = [...predefinedPokemon];
-            renderPokemonGrid();
-            showNotification(`Loaded ${allPokemon.length} Pokémon`);
+            try {
+                await fetchPokemon();
+            } catch (error) {
+                console.error('API fetch failed:', error);
+                pokemonGrid.innerHTML = `
+                    <div class="error-message">
+                        <h3>Failed to load Pokémon</h3>
+                        <button class="fallback-button" onclick="fetchPokemon()">Retry Loading</button>
+                    </div>
+                `;
+            }
         }
 
         // Fetch the first 151 Pokémon from the PokéAPI
@@ -706,12 +543,13 @@
         // Add API key
         addApiKeyButton.addEventListener('click', () => {
             const apiKey = apiKeyInput.value.trim();
+            const comment = apiCommentInput.value.trim();
             if (!apiKey) {
                 showNotification('Please enter a valid API key');
                 return;
             }
-            if (!geminiApiKeys.includes(apiKey)) {
-                geminiApiKeys.push(apiKey);
+            if (!geminiApiKeys.some(k => k.key === apiKey)) {
+                geminiApiKeys.push({ key: apiKey, comment: comment });
                 try {
                     localStorage.setItem('geminiApiKeys', JSON.stringify(geminiApiKeys));
                     renderApiKeys();
@@ -726,20 +564,40 @@
                 showNotification('This API key is already added');
             }
             apiKeyInput.value = '';
+            apiCommentInput.value = '';
         });
 
         // Render API keys list
         function renderApiKeys() {
             apiKeysList.innerHTML = '';
-            geminiApiKeys.forEach((apiKey, index) => {
+            geminiApiKeys.forEach((item, index) => {
                 const listItem = document.createElement('li');
                 listItem.className = 'api-key-item';
                 listItem.innerHTML = `
-                    <span class="key-text">${apiKey}</span>
+                    <span class="key-text">${item.key}</span>
+                    <span class="comment-text">${item.comment || ''}</span>
+                    <button class="edit-btn" onclick="editApiKey(${index})">Edit</button>
                     <button class="delete-btn" onclick="deleteApiKey(${index})">Delete</button>
                 `;
                 apiKeysList.appendChild(listItem);
             });
+        }
+
+        function editApiKey(index) {
+            const item = geminiApiKeys[index];
+            const newKey = prompt('Edit API key', item.key);
+            if (newKey === null) return;
+            const newComment = prompt('Edit comment', item.comment || '');
+            geminiApiKeys[index] = { key: newKey.trim(), comment: newComment.trim() };
+            try {
+                localStorage.setItem('geminiApiKeys', JSON.stringify(geminiApiKeys));
+                renderApiKeys();
+                showNotification('API key updated successfully!');
+            } catch (e) {
+                console.warn('localStorage not available:', e);
+                renderApiKeys();
+                showNotification('API key updated (for this session only)');
+            }
         }
 
         // Delete API key
@@ -778,7 +636,7 @@
                 pokemonGrid.innerHTML = `
                     <div class="error-message">
                         <h3>No Pokémon data available</h3>
-                        <button class="fallback-button" onclick="loadPredefinedPokemon()">Load Default Pokémon</button>
+                        <button class="fallback-button" onclick="fetchPokemon()">Retry Loading</button>
                     </div>
                 `;
                 return;
@@ -882,6 +740,43 @@
             }
         });
 
+        async function callGeminiAPI(prompt) {
+            if (geminiApiKeys.length === 0) {
+                throw new Error('No API keys available');
+            }
+            const totalKeys = geminiApiKeys.length;
+            const errors = [];
+            let attempts = 0;
+            while (attempts < totalKeys * 2) {
+                const keyObj = geminiApiKeys[currentApiKeyIndex];
+                try {
+                    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${keyObj.key}`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            contents: [{ parts: [{ text: prompt }] }],
+                            generationConfig: {
+                                temperature: 0.9,
+                                topP: 1.0,
+                                topK: 32,
+                                maxOutputTokens: 8192,
+                            }
+                        })
+                    });
+                    if (!response.ok) {
+                        const errorData = await response.json();
+                        throw new Error(errorData.error.message);
+                    }
+                    return await response.json();
+                } catch (err) {
+                    errors.push(`${keyObj.comment || keyObj.key.slice(0, 8)}: ${err.message}`);
+                    currentApiKeyIndex = (currentApiKeyIndex + 1) % totalKeys;
+                    attempts++;
+                }
+            }
+            throw new Error('All API keys failed: ' + errors.join('; '));
+        }
+
         // Generate a fusion using Gemini API
         async function generateFusionWithGemini(pokemon1, pokemon2) {
             // Create a fusion name by combining parts of both Pokémon names
@@ -903,39 +798,7 @@
                 `Format your response as a JSON object with the following structure: ` +
                 `{ "name": "${fusionName}", "description": "The description text here", "types": ["type1", "type2"], "abilities": ["ability1", "ability2"] }`;
             
-            // Use the current API key
-            const apiKey = geminiApiKeys[currentApiKeyIndex];
-            
-            // Call the Gemini API
-            const response = await fetch(
-                `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`, 
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        contents: [{
-                            parts: [{
-                                text: prompt
-                            }]
-                        }],
-                        generationConfig: {
-                            temperature: 0.9,
-                            topP: 1.0,
-                            topK: 32,
-                            maxOutputTokens: 8192,
-                        }
-                    })
-                }
-            );
-            
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(`API Error: ${errorData.error.message}`);
-            }
-            
-            const data = await response.json();
+            const data = await callGeminiAPI(prompt);
             
             // Extract the text response
             const textResponse = data.candidates[0].content.parts[0].text;


### PR DESCRIPTION
## Summary
- Load the first 151 Pokémon directly from the PokéAPI instead of maintaining a large hard-coded list.
- Allow multiple Gemini API keys with optional comments, plus edit and delete controls stored in localStorage.
- Introduce a rotation mechanism that retries with each API key up to two rounds and reports aggregated failures.

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_689b85f7f34083219aa567c6d190255d