### PR TITLE
Avoid duplicate fusion image requests

### DIFF
--- a/Pokemon_fusion.html
+++ b/Pokemon_fusion.html
@@ -857,12 +857,27 @@
             if (!validUrl) {
                 imageUrl = 'about:blank';
             }
-            fusionResultDiv.innerHTML = `
-                <img class="fusion-image" src="${imageUrl}" alt="${fusionResult.name}">
-                <p class="fusion-name">${fusionResult.name}</p>
-            `;
+            // Update the existing result image
             resultImage.src = imageUrl;
             resultImage.alt = fusionResult.name;
+
+            // Display the updated image in the fusion result without creating a new <img>
+            fusionResultDiv.innerHTML = `
+                <div class="fusion-image"></div>
+                <p class="fusion-name">${fusionResult.name}</p>
+            `;
+            const fusionImageEl = fusionResultDiv.querySelector('.fusion-image');
+            const applyFusionImage = () => {
+                fusionImageEl.style.backgroundImage = `url('${resultImage.src}')`;
+                fusionImageEl.style.backgroundSize = 'contain';
+                fusionImageEl.style.backgroundRepeat = 'no-repeat';
+                fusionImageEl.style.backgroundPosition = 'center';
+            };
+            if (resultImage.complete) {
+                applyFusionImage();
+            } else {
+                resultImage.addEventListener('load', applyFusionImage, { once: true });
+            }
             resultName.textContent = fusionResult.name;
             // Create a detailed description with types and abilities
             const typesText = fusionResult.types.join(', ');


### PR DESCRIPTION
## Summary
- Reuse the existing `#resultImage` element for the fusion preview instead of creating a new `<img>`
- Apply the fusion result image via CSS background to the preview
- Ensure the result image and preview share a single network request

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9a069d8883218cf3c55167851815